### PR TITLE
Support dynamic leaf lengths when DisableHashLeaves is true

### DIFF
--- a/merkle.go
+++ b/merkle.go
@@ -21,7 +21,7 @@ type TreeOptions struct {
 
 	// DisableHashLeaves determines whether leaf nodes should be hashed or not. By doing disabling this behavior,
 	// you can use a different hash function for leaves or generate a tree that contains already hashed
-	// values. If this is disabled, a length of 32 bytes is enforced for all leaves.
+	// values.
 	DisableHashLeaves bool
 }
 
@@ -182,20 +182,24 @@ func (self *Tree) generateNodeLevel(below []Node, current []Node,
 }
 
 func (self *Tree) generateNode(left, right []byte, h hash.Hash) (Node, error) {
-	data := make([]byte, h.Size()*2)
 	if right == nil {
-		b := data[:h.Size()]
-		copy(b, left)
-		return Node{Hash: b}, nil
+		data := make([]byte, len(left))
+		copy(data, left)
+		return Node{Hash: data}, nil
+	} else if left == nil {
+		data := make([]byte, len(right))
+		copy(data, right)
+		return Node{Hash: data}, nil
 	}
-	firstHalf := left
-	secondHalf := right
+
+	data := make([]byte, len(left)+len(right))
 	if self.Options.EnableHashSorting && bytes.Compare(left, right) > 0 {
-		firstHalf = right
-		secondHalf = left
+		copy(data[:len(right)], right)
+		copy(data[len(right):], left)
+	} else {
+		copy(data[:len(left)], left)
+		copy(data[len(left):], right)
 	}
-	copy(data[:h.Size()], firstHalf)
-	copy(data[h.Size():], secondHalf)
 
 	return NewNode(h, data)
 }

--- a/merkle_test.go
+++ b/merkle_test.go
@@ -490,6 +490,73 @@ func TestTreeGenerate_DisableHashLeaves(t *testing.T) {
 	assert.Equal(t, tree.Root().Hash, treeHashedLeaves.Root().Hash)
 }
 
+func TestTreeGenerate_DisableHashLeaves_DynamicLeafLengths(t *testing.T) {
+	alpha := sha256.Sum256([]byte("alpha"))
+	beta := md5.Sum([]byte("beta"))
+	items := [][]byte{alpha[:], beta[:]}
+
+	tree := NewTreeWithOpts(TreeOptions{false, true})
+	err := tree.Generate(items, sha256.New())
+	assert.Nil(t, err)
+
+	alphaPlusBeta := append(alpha[:], beta[:]...)
+	expectedHash := sha256.Sum256(alphaPlusBeta)
+
+	assert.Equal(t, expectedHash[:], tree.Root().Hash[:])
+}
+
+func TestTreeGenerate_DisableHashLeaves_DynamicLeafLengths_EnableHashSorting(t *testing.T) {
+	alpha := sha256.Sum256([]byte("alpha"))
+	beta := md5.Sum([]byte("beta"))
+	items := [][]byte{beta[:], alpha[:]}
+
+	tree := NewTreeWithOpts(TreeOptions{true, true})
+	err := tree.Generate(items, sha256.New())
+	assert.Nil(t, err)
+
+	alphaPlusBeta := append(alpha[:], beta[:]...)
+	expectedHash := sha256.Sum256(alphaPlusBeta)
+
+	assert.Equal(t, expectedHash[:], tree.Root().Hash[:])
+}
+
+func TestTreeGenerate_DisableHashLeaves_RightNil(t *testing.T) {
+	a := md5.Sum([]byte("a"))
+	b := md5.Sum([]byte("b"))
+	c := md5.Sum([]byte("c"))
+	items := [][]byte{a[:], b[:], c[:], nil}
+
+	tree := NewTreeWithOpts(TreeOptions{false, true})
+	err := tree.Generate(items, sha256.New())
+	assert.Nil(t, err)
+
+	ab := append(a[:], b[:]...)
+	ab_hashed := sha256.Sum256(ab)
+	abc := append(ab_hashed[:], c[:]...)
+	expectedHash := sha256.Sum256(abc)
+
+	assert.Equal(t, expectedHash[:], tree.Root().Hash[:])
+}
+
+func TestTreeGenerate_DisableHashLeaves_LeftNil(t *testing.T) {
+	a := md5.Sum([]byte("a"))
+	b := md5.Sum([]byte("b"))
+	c := md5.Sum([]byte("c"))
+	items := [][]byte{nil, a[:], b[:], c[:]}
+
+	tree := NewTreeWithOpts(TreeOptions{false, true})
+	err := tree.Generate(items, sha256.New())
+	assert.Nil(t, err)
+
+	bc := append(b[:], c[:]...)
+	bc_hashed := sha256.Sum256(bc)
+	abc := append(a[:], bc_hashed[:]...)
+	expectedHash := sha256.Sum256(abc)
+
+	assert.Equal(t, expectedHash[:], tree.Root().Hash[:])
+}
+
+
 func TestGenerateNodeHashOfUnbalance(t *testing.T) {
 	tree := Tree{}
 	tree.Options.EnableHashSorting = true


### PR DESCRIPTION
related to https://github.com/centrifuge/precise-proofs/issues/80

The existing implementation assumes all leaves have the same length when `DisableHashLeaves` is true. This pull request allows users to hash leaves using different functions than other nodes. 

Other notable change:
- null left nodes are now ignored instead of being implicitly converted into empty bytes

cc: @lucasvo 